### PR TITLE
Priorities: fix sorting of registrations

### DIFF
--- a/app/registration/api.py
+++ b/app/registration/api.py
@@ -97,7 +97,7 @@ def api_registration_priorities():
         return "OK"
 
     # GET requiest: return list of registrations ordered by priority
-    registrations = sorted(Registration.query.filter_by(uni_id = g.uni.id), key=lambda r: r.priority)
+    registrations = sorted(Registration.query.filter_by(uni_id = g.uni.id), key=lambda r: r.priority or 0)
 
     def format_reg(reg):
         return {


### PR DESCRIPTION
Registration priorities can be None, which is not sortable. Represent
these with 0 in the sorting.