### PR TITLE
Fix registration priority POST endpoint

### DIFF
--- a/app/registration/api.py
+++ b/app/registration/api.py
@@ -88,7 +88,7 @@ def api_registration_priorities():
             db.session.add(reg)
 
         # Set all remaining priorities as unconfirmed
-        for reg in registrations:
+        for reg in registrations.values():
             reg.confirmed = False
             reg.priority = None
             db.session.add(reg)


### PR DESCRIPTION
We're erroneously iterating over dictionary keys here, not values.
Iterate over the registration objects, not their ID's.